### PR TITLE
Fix code scanning alert no. 1: Incomplete string escaping or encoding

### DIFF
--- a/lmo/addon/classlib/doc/media/lib/classTree.js
+++ b/lmo/addon/classlib/doc/media/lib/classTree.js
@@ -437,8 +437,10 @@ WebFXTreeItem.prototype.toString = function (nItem, nItemCount) {
 	}
 	else if (!this.icon) { this.icon = webFXTreeConfig.fileIcon; }
 	var label = this.text;
-	label = label.replace('<', '<');
-	label = label.replace('>', '>');
+	label = label.replace(/</g, '&lt;');
+	label = label.replace(/>/g, '&gt;');
+	label = label.replace(/&/g, '&amp;');
+	label = label.replace(/"/g, '&quot;');
 	var str = "<div id=\"" + this.id + "\" ondblclick=\"webFXTreeHandler.toggle(this);\" class=\"webfx-tree-item\" onkeydown=\"return webFXTreeHandler.keydown(this)\">";
 	str += indent;
 	str += "<img id=\"" + this.id + "-plus\" src=\"" + ((this.folder)?((this.open)?((this.parentNode._last)?webFXTreeConfig.lMinusIcon:webFXTreeConfig.tMinusIcon):((this.parentNode._last)?webFXTreeConfig.lPlusIcon:webFXTreeConfig.tPlusIcon)):((this.parentNode._last)?webFXTreeConfig.lIcon:webFXTreeConfig.tIcon)) + "\" onclick=\"webFXTreeHandler.toggle(this);\">"


### PR DESCRIPTION
Fixes [https://github.com/henshingly/lmo_php8/security/code-scanning/1](https://github.com/henshingly/lmo_php8/security/code-scanning/1)

To fix the problem, we need to ensure that all occurrences of the `<` and `>` characters in the `label` are replaced. This can be achieved by using a regular expression with the global flag (`g`). Additionally, we should handle other potentially dangerous characters like `&` and `"` to prevent XSS attacks comprehensively.

The best way to fix this is to use a well-tested sanitization library. However, if we need to stick to the current approach, we should update the `replace` calls to use regular expressions with the global flag.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
