### PR TITLE
remove magic functions c & d

### DIFF
--- a/lmo/lang/lang-Bosanski.txt
+++ b/lmo/lang/lang-Bosanski.txt
@@ -578,6 +578,7 @@
 577=Mjesto
 578=Učesnici UEFA konferencijske lige
 579=Ovdje unesite broj učesnika UEFA Conference League
+580=Kliknite ovdje za informacije o ovoj skripti
 590=Nova LMO verzija je objavljena.
 591=Može se preuzeti OVDJE!
 800=Režim doigravanja - postavka za kućnu igru

--- a/lmo/lang/lang-Cestina.txt
+++ b/lmo/lang/lang-Cestina.txt
@@ -578,6 +578,7 @@
 577=Místo
 578=Účastníci konferenční ligy UEFA
 579=Sem zadejte počet účastníků konferenční ligy UEFA
+580=Kliknutím sem získáte informace o tomto skriptu
 590=Byla vydána nová verze LMO.
 591=Lze stáhnout ZDE!
 800=Režim Playoff – nastavení domácí hry

--- a/lmo/lang/lang-Deutsch.txt
+++ b/lmo/lang/lang-Deutsch.txt
@@ -578,6 +578,7 @@
 577=Platz
 578=UEFA Conference League Teilnehmer
 579=Geben Sie hier die Anzahl der UEFA Conference League-Teilnehmer an
+580=Klicken Sie hier, um Informationen über dieses Skript zu erhalten
 590=Eine neue LMO-Version wurde veröffentlicht.
 591=Diese kann HIER heruntergeladen werden!
 800=Playoff Modus - Heimspieleinstellung

--- a/lmo/lang/lang-English.txt
+++ b/lmo/lang/lang-English.txt
@@ -578,6 +578,7 @@
 577=Position
 578=UEFA Conference League participants
 579=Enter the number of UEFA Conference League participants here
+580=Click here to get information about this script
 590=A new LMO version has been released.
 591=It can be downloaded HERE!
 800=Playoff mode - home game setting

--- a/lmo/lang/lang-Espanol.txt
+++ b/lmo/lang/lang-Espanol.txt
@@ -578,6 +578,7 @@
 577=Posición
 578=Participantes de la Liga de Conferencias de la UEFA
 579=Ingrese aquí el número de participantes de la UEFA Conference League
+580=Haga clic aquí para obtener información sobre este script
 590=Se ha lanzado una nueva versión de LMO.
 591=¡Se puede descargar AQUÍ!
 800=Playoff Modus - configuración del juego en casa

--- a/lmo/lang/lang-Francais.txt
+++ b/lmo/lang/lang-Francais.txt
@@ -578,6 +578,7 @@
 577=Position
 578=Participants à l'UEFA Conference League
 579=Entrez ici le nombre de participants à l'UEFA Conference League
+580=Cliquez ici pour obtenir des informations sur ce script
 590=Une nouvelle version LMO a été publiée.
 591=Il peut être téléchargé ICI !
 800=Mode Playoffs - réglage du jeu à domicile

--- a/lmo/lang/lang-Hrvatski.txt
+++ b/lmo/lang/lang-Hrvatski.txt
@@ -578,6 +578,7 @@
 577=Mjesto
 578=Sudionici UEFA Lige konferencija
 579=Ovdje unesite broj sudionika UEFA Lige konferencija
+580=Kliknite ovdje za informacije o ovoj skripti
 590=Izdana je nova LMO verzija.
 591=Može se preuzeti OVDJE!
 800=Način doigravanja - postavka za domaću igru

--- a/lmo/lang/lang-Italiano.txt
+++ b/lmo/lang/lang-Italiano.txt
@@ -578,6 +578,7 @@
 577=Posizione
 578=Partecipanti alla UEFA Conference League
 579=Inserisci qui il numero dei partecipanti alla UEFA Conference League
+580=Clicca qui per avere informazioni su questo script
 590=È stata rilasciata una nuova versione di LMO.
 591=Può essere scaricato QUI!
 800=Modalità playoff: impostazione della partita in casa

--- a/lmo/lang/lang-Magyar.txt
+++ b/lmo/lang/lang-Magyar.txt
@@ -578,6 +578,7 @@
 577=Pozíció
 578=UEFA Konferencia Liga résztvevői
 579=Ide írja be az UEFA Conference League résztvevőinek számát
+580=Kattintson ide, ha információkat szeretne kapni erről a szkriptről
 590=Az új LMO verzió megjelent.
 591=Innen letölthető!
 800=Playoff mód - otthoni játék beállítása

--- a/lmo/lang/lang-Nederlands.txt
+++ b/lmo/lang/lang-Nederlands.txt
@@ -578,6 +578,7 @@
 577=Positie
 578=UEFA Conference League-deelnemers
 579=Vul hier het aantal UEFA Conference League-deelnemers in
+580=Klik hier voor informatie over dit script
 590=Er is een nieuwe LMO-versie uitgebracht.
 591=Het kan HIER worden gedownload!
 800=Playoff-modus - thuiswedstrijdinstelling

--- a/lmo/lang/lang-Norsk.txt
+++ b/lmo/lang/lang-Norsk.txt
@@ -578,6 +578,7 @@
 577=Posisjon
 578=UEFA Conference League-deltakere
 579=Skriv inn antall deltakere i UEFA Conference League her
+580=Klikk her for å få informasjon om dette skriptet
 590=En ny LMO-versjon har blitt utgitt.
 591=Den kan lastes ned HER!
 800=Sluttspillmodus – Hjemmespillinnstilling

--- a/lmo/lang/lang-Portugues.txt
+++ b/lmo/lang/lang-Portugues.txt
@@ -578,6 +578,7 @@
 577=Posição
 578=Participantes da UEFA Conference League
 579=Insira aqui o número de participantes da UEFA Conference League
+580=Clique aqui para obter informações sobre este script
 590=Uma nova versão do LMO foi lançada.
 591=Pode ser baixado AQUI!
 800=Modo Playoff - configuração do jogo em casa

--- a/lmo/lang/lang-Romanian.txt
+++ b/lmo/lang/lang-Romanian.txt
@@ -578,6 +578,7 @@
 577=Poziţie
 578=Participanți la UEFA Conference League
 579=Introduceți aici numărul de participanți la UEFA Conference League
+580=Faceți clic aici pentru a obține informații despre acest script
 590=O nouă versiune LMO a fost lansată.
 591=Poate fi descărcat AICI!
 800=Mod playoff - setarea jocului de acasă

--- a/lmo/lang/lang-Slovenskega.txt
+++ b/lmo/lang/lang-Slovenskega.txt
@@ -578,6 +578,7 @@
 577=Položaj
 578=Udeleženci konferenčne lige UEFA
 579=Tukaj vnesite število udeležencev konferenčne lige UEFA
+580=Kliknite tukaj za informacije o tem skriptu
 590=Izdana je bila nova različica LMO.
 591=Lahko ga prenesete TUKAJ!
 800=Način končnice - nastavitev domače igre

--- a/lmo/lmo-langload.php
+++ b/lmo/lmo-langload.php
@@ -91,28 +91,3 @@ while (false !== ($f = readdir($handle))) {
 
 $orgpkt = $text[37];
 $orgtor = $text[38];
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-///*
-  if (!function_exists("c")){function c($c){if($c==1)return(base64_decode("PGFjcm9ueW0gdGl0bGU9IkxpZ2EgTWFuYWdlciBPbmxpbmUgZm9yIFBIUCA4LngiPkxNTzwvYWNyb255bT4gNCBmb3IgUEhQOCAtIDxhIGhyZWY9Ig=="));return(base64_decode("aHR0cHM6Ly93d3cubGlnYS1tYW5hZ2VyLW9ubGluZS5kZS8iIHRpdGxlPSJDbGljayBoZXJlIHRvIGdldCBpbmZvcm1hdGlvbnMgYWJvdXQgdGhpcyBzY3JpcHQiPiYjMTY5OyAxOTk3LTIwMjMgTE1PLUdyb3VwPC9hPg=="));}}
-  if (!function_exists("d")){function d($c){if(strpos(htmlentities($c),htmlentities(base64_decode("PCEtLUluZm9saW5rLS0+")))>0){false;}else{ eval(base64_decode("ZWNobyAnPGFjcm9ueW0gdGl0bGU9IkxpZ2EgTWFuYWdlciBPbmxpbmUgZm9yIFBIUCA4LngiPkxNTzwvYWNyb255bT4gNCBmb3IgUEhQOCAtIDxhIGhyZWY9Imh0dHA6Ly93d3cubGlnYS1tYW5hZ2VyLW9ubGluZS5kZS8iIHRpdGxlPSJDbGljayBoZXJlIHRvIGdldCBpbmZvcm1hdGlvbnMgYWJvdXQgdGhpcyBzY3JpcHQiPiYjMTY5OyAxOTk3LTIwMjQgTE1PLUdyb3VwPC9hPic7"));}}}//*/?>

--- a/lmo/lmo-showmain2.php
+++ b/lmo/lmo-showmain2.php
@@ -209,7 +209,6 @@ if ($file!="") {
     //Spieler-Addon
   }
   if ($action=="info")                                    {require(PATH_TO_LMO."/lmo-showinfo.php");}
-  $p0="p1";$$p0=c(1).c(0);
 } elseif ($backlink==1 && $action!="tipp")                {require(PATH_TO_LMO."/lmo-showdir.php");}
 
 if ($action=="tipp" && $eintippspiel==1) {require(PATH_TO_ADDONDIR."/tipp/lmo-tippstart.php");}
@@ -292,9 +291,15 @@ if ($eintippspiel==1) {
     $output_tippspiel.=$action!="tipp"?       "<a href='{$addm}tipp' title='{$text['tipp'][0]}'>{$text['tipp'][0]}</a>&nbsp;&nbsp;":$text['tipp'][0]."&nbsp;&nbsp;";
   }
 }
-d($template->toString());
 //Tippspiel-Addon
 
+$infoLink = '<acronym title="Liga Manager Online for PHP 8.x">LMO</acronym> 4 for PHP8 - <a target="_blank" href="https://www.liga-manager-online.de/" title="' . $text[580] . '">' . $text[55] . '</a>';
+
+if (!$template->checkPlaceholderExists('__global__', 'Infolink'))
+{
+  trigger_error("'Infolink' is missing in template'", E_USER_WARNING);
+  echo $infoLink; 
+}
 
 //Template ausgeben
 $template->setVariable("Ligenuebersicht", $output_ligenuebersicht);
@@ -311,7 +316,7 @@ $template->setVariable("Kalender", $output_kalender);
 $template->setVariable("Ergebnisse", $output_ergebnisse);
 $template->setVariable("Spielplan", $output_spielplan);
 $template->setVariable("Info", $output_info);
-$template->setVariable("Infolink", $p1);
+$template->setVariable("Infolink", $infoLink);
 $template->setVariable("Sprachauswahl", $output_sprachauswahl);
 $template->setVariable("Titel", $output_titel);
 $template->setVariable("Stylesheet", $output_stylesheet . $output_stylesheet2);


### PR DESCRIPTION
Hallo,

um der GNU-Lizenz zu entsprechen, solle man aus meiner Sicht nicht mit derartigen Mitteln arbeiten.

Es reicht eigentlich auch aus, es in seinem Impressum mit aufzunehmen. Es muss nicht an dieser Stelle stehen. Außerdem könnte man es auch mittels "insichtbarem HTML" auch austricksen.

Zusätzlich ist ein `eval` mit base64-codiertem Code nicht gerade das geschickteste, was man heutzutage bzgl. Security machen sollte.